### PR TITLE
Migrate to grub-mkrelpath (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ Otherwise, you can run this command to revert all changes made by the script:
  * `--hold` Don't reboot or power off after installation
  * `--power-off` Power off after installation rather than reboot
  * `--architecture <string>` e.g. `amd64`, `i386`, `arm64`, `armhf`, etc.
- * `--boot-directory <string>` Automatically set to `/` if there is an individual boot partition otherwise set to `/boot`. You can try to treak this if needed (for example setting subvolume for btrfs)
  * `--firmware` Load additional [non-free firmwares](https://wiki.debian.org/Firmware#Firmware_during_the_installation)
  * `--no-force-efi-extra-removable` [See](https://wiki.debian.org/UEFI#Force_grub-efi_installation_to_the_removable_media_path)
  * `--grub-timeout 5` How many seconds the GRUB menu shows before entering the installer

--- a/debi.sh
+++ b/debi.sh
@@ -232,7 +232,6 @@ ssh_port=
 hold=false
 power_off=false
 architecture=
-boot_directory=
 firmware=false
 force_efi_extra_removable=true
 grub_timeout=5
@@ -411,10 +410,6 @@ while [ $# -gt 0 ]; do
             architecture=$2
             shift
             ;;
-        --boot-directory)
-            boot_directory=$2
-            shift
-            ;;
         --firmware)
             firmware=true
             ;;
@@ -462,8 +457,7 @@ done
 [ -n "$authorized_keys_url" ] && ! download "$authorized_keys_url" /dev/null &&
 err "Failed to download SSH authorized public keys from \"$authorized_keys_url\""
 
-installer="debian-$suite"
-installer_directory="/boot/$installer"
+installer_directory="/boot/debian-$suite"
 
 save_preseed='cat'
 [ "$dry_run" = false ] && {
@@ -806,15 +800,7 @@ EOF
     save_grub_cfg="tee -a $grub_cfg"
 }
 
-[ -z "$boot_directory" ] && {
-    if grep -q '\s/boot\s' /proc/mounts; then
-        boot_directory=/
-    else
-        boot_directory=/boot/
-    fi
-}
-
-installer_directory="$boot_directory$installer"
+installer_directory=$(grub-mkrelpath "$installer_directory")
 
 kernel_params="$kernel_params lowmem/low=1"
 
@@ -827,6 +813,7 @@ menuentry 'Debian Installer' --id debi {
     insmod part_gpt
     insmod ext2
     insmod xfs
+    insmod btrfs
     linux $installer_directory/linux$kernel_params
     initrd $initrd
 }


### PR DESCRIPTION
* Add btrfs support

* Fix bootloader path when rootfs is already btrfs

* Breaking change: remove --boot-directory
grub-mkrelpath is used instead

Co-authored-by: Bohan Yang <youthdna@live.com>
Co-authored-by: Bohan Yang <8384161+bohanyang@users.noreply.github.com>